### PR TITLE
Remove jquery countdown plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,7 +535,6 @@
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     
         <!-- 2. Muat Plugin yang Bergantung pada jQuery -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.countdown/2.2.0/jquery.countdown.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.4/js/lightbox.min.js"></script>
         
        


### PR DESCRIPTION
## Summary
- drop unused jquery.countdown plugin script

## Testing
- `node - <<'NODE' const fs=require('fs'); const html=fs.readFileSync('index.html','utf8'); const match=html.match(/function initJavaneseCountdown\(targetDate\) {[\s\S]*?setInterval\(updateCountdown, 1000\);\n\s*}/); const fnStr=match[0]; eval(fnStr); const map={ '[data-days]': {textContent:'00'}, '[data-hours]': {textContent:'00'}, '[data-minutes]': {textContent:'00'}, '[data-seconds]': {textContent:'00'} }; global.document={querySelector:(sel)=>map[sel]}; initJavaneseCountdown(new Date(Date.now()+5000).toISOString()); setTimeout(()=>{console.log(map); process.exit(0);}, 1200); NODE`
- `rg -n '\.countdown\(' -g '*.js' -g '*.html' -g '!js/jquery.countdown*.js' -g '!js/wdp.min.js' -g '!js/elements-handlers.min.js' -g '!js/webpack-pro.runtime.min.js' -g '!dist/*.js'`
- `rg -n 'jquery.countdown' -g '*.js' -g '*.html'`


------
https://chatgpt.com/codex/tasks/task_e_68b0240e417c8320853943368471850b